### PR TITLE
V1webhooks

### DIFF
--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -54,12 +54,8 @@ class MailgunFaxesController < ApplicationController
     user = User.includes(:fax_numbers).find_by(email: sender)
 
     # Currently fails if user is not in the DB
-
-  	if params['attachment-count'].nil? # <-- user forgot to add an attachment
-  		sent_fax_object = "Only attached files may be converted into a fax."
-  	else # <-- Attachment is present
+    if !params['attachment-count'].nil?
 	    attachment_count = params['attachment-count'].to_i
-
 	    i = 1
 	    while i <= attachment_count do
 	      output_file = "/tmp/#{Time.now.to_i}-#{rand(200)}-" + params["attachment-#{i}"].original_filename
@@ -70,10 +66,12 @@ class MailgunFaxesController < ApplicationController
 	    end
 	  end
 
-    if user && user.fax_numbers.present?
+    if user && user.fax_numbers.present? && !params['attachment-count'].nil?
 	 		sent_fax_object = Fax.create_fax_from_email(sender, params['recipient'], files, user)
 	 	else
-	 		sent_fax_object += "You are not currently linked to the fax number you attempted to fax."
+	 		sent_fax_object = ''
+	 		sent_fax_object += "Only attachments may be sent as a fax. Please add an attachment. " if params['attachment-count'].nil?
+	 		sent_fax_object += "You are notlinked to the fax number you attempted to fax. " if !user || !user.fax_numbers.present?
 	 	end
 
  		if sent_fax_object.class != String && user.fax_numbers.present?

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -52,9 +52,10 @@ class MailgunFaxesController < ApplicationController
 	def mailgun(files = [])
     sender = Mail::AddressList.new(params['from']).addresses.first.address
     user = User.includes(:fax_numbers).find_by(email: sender)
-    p "55"
+
     # Currently fails if user is not in the DB
-    p "57"
+    p "============================================================="
+    p params['attachment-count']
     attachment_count = params['attachment-count'].to_i
     i = 1
     while i <= attachment_count do
@@ -64,13 +65,14 @@ class MailgunFaxesController < ApplicationController
       files.push(output_file)
       i += 1
     end
-    p "67"
+
+
     if user && user.fax_numbers.present?
 	 		sent_fax_object = Fax.create_fax_from_email(sender, params['recipient'], files, user)
 	 	else
 	 		sent_fax_object = "You are not currently linked to the fax number you attempted to fax."
 	 	end
-	 	p "73"
+
  		if sent_fax_object.class != String && user.fax_numbers.present?
 			api_response = Fax.get_fax_information(sent_fax_object.id)
 		else

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -2,15 +2,14 @@ class MailgunFaxesController < ApplicationController
 	skip_before_action :verify_authenticity_token
 
 	def fax_received
-		p "FAX_RECEIVED"
 		p params
 		@fax = JSON.parse(params['fax'])
 		p "FAX RECEIVED @FAX"
 		p @fax
-    p recipient_number = Phonelib.parse(@fax['to_number']).e164
-    p fax_number = FaxNumber.find_by(fax_number: recipient_number)
+    recipient_number = Phonelib.parse(@fax['to_number']).e164
+    fax_number = FaxNumber.find_by(fax_number: recipient_number)
 
-    p email_addresses = UserFaxNumber.where(fax_number_id: fax_number.id).all.map do |fax_num_email_obj|
+    email_addresses = UserFaxNumber.where(fax_number_id: fax_number.id).all.map do |fax_num_email_obj|
     	fax_num_email_obj.user.email
     end
 
@@ -23,7 +22,8 @@ class MailgunFaxesController < ApplicationController
 		##############################################################
 
 		###################### V1 WEBHOOK CODE HERE ###################
-	  p fax_from = @fax['from_number']
+	  fax_from = @fax['from_number']
+	  p "FILENAME FILENAME"
     p fax_file_name = params['filename']['filename']
     p fax_file_contents = params['filename']['tempfile'].read
     ###############################################################

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -69,7 +69,7 @@ class MailgunFaxesController < ApplicationController
     if user && user.fax_numbers.present? && !params['attachment-count'].nil?
 	 		sent_fax_object = Fax.create_fax_from_email(sender, params['recipient'], files, user)
 	 	else
-	 		sent_fax_object = params['attachment-count'].nil?
+	 		sent_fax_object = ""
 	 		sent_fax_object += "Only attachments may be sent as a fax. Please add an attachment. " if params['attachment-count'].nil?
 	 		sent_fax_object += "You are not linked to the fax number you attempted to fax. " if !user || !user.fax_numbers.present?
 	 	end

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -15,9 +15,19 @@ class MailgunFaxesController < ApplicationController
     end
 
     if email_addresses.present? # requires the User to be linked to a fax number
-	    p fax_from = @fax['from_number']
-	  	p fax_file_name = params['file'].original_filename
-	    p fax_file_contents = params['file'].read
+
+  	##################### V2.1 WEBHOOK CODE HERE #################
+    ###  fax_from = @fax['from_number']
+  	###  fax_file_name = params['file'].original_filename
+    ###  fax_file_contents = params['file'].read
+		##############################################################
+
+		###################### V1 WEBHOOK CODE HERE ###################
+	  p fax_from = @fax['from_number']
+    p fax_file_name = params['filename']['filename']
+    p fax_file_contents = params['filename']['tempfile'].read
+    ###############################################################
+
 
 	    p email_subject = "Fax received from #{fax_from}"
 			MailgunMailer.fax_email(email_addresses, email_subject, @fax, fax_file_name, fax_file_contents).deliver_now

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -46,8 +46,8 @@ class MailgunFaxesController < ApplicationController
 	    if @fax["status"] == "success"
 	    	p email_subject = "Your fax was sent successfully"
 	    else
-	    	@fax["most_common_error"] = Fax.most_common_error(@fax)
-	    	email_subject = "Your fax failed because: #{@fax["most_common_error"]}"
+	    	p @fax["most_common_error"] = Fax.most_common_error(@fax)
+	    	p email_subject = "Your fax failed because: #{@fax["most_common_error"]}"
 	    end
 
 			MailgunMailer.fax_email(email_addresses, email_subject, @fax).deliver_now

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -69,9 +69,11 @@ class MailgunFaxesController < ApplicationController
     if user && user.fax_numbers.present? && !params['attachment-count'].nil?
 	 		sent_fax_object = Fax.create_fax_from_email(sender, params['recipient'], files, user)
 	 	else
-	 		sent_fax_object = ''
-	 		sent_fax_object += "Only attachments may be sent as a fax. Please add an attachment. " if params['attachment-count'].nil?
-	 		sent_fax_object += "You are notlinked to the fax number you attempted to fax. " if !user || !user.fax_numbers.present?
+	 		if params['attachment-count'].nil?
+	 			sent_fax_object = "Only attachments may be sent as a fax. Please add an attachment. "
+	 		else
+	 			sent_fax_object = "You are not linked to the fax number you attempted to fax. "
+	 		end
 	 	end
 
  		if sent_fax_object.class != String && user.fax_numbers.present?

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -47,7 +47,7 @@ class MailgunFaxesController < ApplicationController
 	    	p email_subject = "Your fax was sent successfully"
 	    else
 	    	p @fax["most_common_error"] = Fax.most_common_error(@fax)
-	    	p email_subject = "Your fax failed because: #{@fax["most_common_error"]}"
+	    	p email_subject = "Your fax was not delivered because: #{@fax["most_common_error"]}"
 	    end
 
 			MailgunMailer.fax_email(email_addresses, email_subject, @fax).deliver_now

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -66,6 +66,11 @@ class MailgunFaxesController < ApplicationController
 	    end
 	  end
 
+	  p "==========="
+	  p user
+	  p user.fax_numbers
+	  p "==========="
+
     if user && user.fax_numbers.present? && !params['attachment-count'].nil?
 	 		sent_fax_object = Fax.create_fax_from_email(sender, params['recipient'], files, user)
 	 	else

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -2,6 +2,8 @@ class MailgunFaxesController < ApplicationController
 	skip_before_action :verify_authenticity_token
 
 	def fax_received
+		p "FAX_RECEIVED"
+		p params
 		@fax = JSON.parse(params['fax'])
     recipient_number = Phonelib.parse(@fax['to_number']).e164
     fax_number = FaxNumber.find_by(fax_number: recipient_number)
@@ -21,6 +23,8 @@ class MailgunFaxesController < ApplicationController
 	end
 
 	def fax_sent
+		p "FAX SENT"
+		p params
 		@fax = JSON.parse(params['fax'])
 		email_addresses = User.includes(:fax_numbers).find_by(fax_tag: @fax['tags']['sender_email_fax_tag']).email
 
@@ -38,6 +42,8 @@ class MailgunFaxesController < ApplicationController
 	end
 
 	def mailgun(files = [])
+		p "MAILGUN"
+		p params
     sender = Mail::AddressList.new(params['from']).addresses.first.address
     user = User.includes(:fax_numbers).find_by(email: sender)
 

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -54,7 +54,7 @@ class MailgunFaxesController < ApplicationController
     user = User.includes(:fax_numbers).find_by(email: sender)
 
     # Currently fails if user is not in the DB
-    if !params['attachment-count'].nil?
+    if params['attachment-count'].nil?
 	    attachment_count = params['attachment-count'].to_i
 	    i = 1
 	    while i <= attachment_count do
@@ -66,17 +66,12 @@ class MailgunFaxesController < ApplicationController
 	    end
 	  end
 
-	  p "==========="
-	  p user
-	  p user.fax_numbers
-	  p "==========="
-
     if user && user.fax_numbers.present? && !params['attachment-count'].nil?
 	 		sent_fax_object = Fax.create_fax_from_email(sender, params['recipient'], files, user)
 	 	else
-	 		sent_fax_object = ""
-	 		sent_fax_object += "Only attachments may be sent as a fax. Please add an attachment. " if params['attachment-count'].nil?
-	 		sent_fax_object += "You are not linked to the fax number you attempted to fax. " if !user || !user.fax_numbers.present?
+	 		sent_fax_object = ''
+	 		sent_fax_object += "Only attached files may be sent as a fax. Please add an attachment. " if params['attachment-count'].nil?
+	 		sent_fax_object += "You are not linked to the fax number you attempted to fax. " if !user && !user.fax_numbers.present?
 	 	end
 
  		if sent_fax_object.class != String && user.fax_numbers.present?

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -24,8 +24,8 @@ class MailgunFaxesController < ApplicationController
 		###################### V1 WEBHOOK CODE HERE ###################
 	  fax_from = @fax['from_number']
 	  p "FILENAME FILENAME"
-    p fax_file_name = params['filename']['filename']
-    p fax_file_contents = params['filename']['tempfile'].read
+    p fax_file_name = params['filename'].original_filename
+    p fax_file_contents = params['filename'].tempfile.read
     ###############################################################
 
 

--- a/app/controllers/mailgun_faxes_controller.rb
+++ b/app/controllers/mailgun_faxes_controller.rb
@@ -69,11 +69,9 @@ class MailgunFaxesController < ApplicationController
     if user && user.fax_numbers.present? && !params['attachment-count'].nil?
 	 		sent_fax_object = Fax.create_fax_from_email(sender, params['recipient'], files, user)
 	 	else
-	 		if params['attachment-count'].nil?
-	 			sent_fax_object = "Only attachments may be sent as a fax. Please add an attachment. "
-	 		else
-	 			sent_fax_object = "You are not linked to the fax number you attempted to fax. "
-	 		end
+	 		sent_fax_object = params['attachment-count'].nil?
+	 		sent_fax_object += "Only attachments may be sent as a fax. Please add an attachment. " if params['attachment-count'].nil?
+	 		sent_fax_object += "You are not linked to the fax number you attempted to fax. " if !user || !user.fax_numbers.present?
 	 	end
 
  		if sent_fax_object.class != String && user.fax_numbers.present?

--- a/app/models/fax.rb
+++ b/app/models/fax.rb
@@ -42,6 +42,7 @@ class Fax < ApplicationRecord
 
 		# if there are two error_codes with the same frequency, the error found first (first recipient) takes precedence
 		def most_common_error(fax, errors = {})
+			p "================================ MOST COMMON ERROR METHOD HERE ============================="
 			p fax
 			fax["recipients"].each do |recipient|
 		  	p key = recipient["error_message"]

--- a/app/models/fax.rb
+++ b/app/models/fax.rb
@@ -5,7 +5,6 @@ class Fax < ApplicationRecord
 		end
 
 		def create_fax(options)
-			ENV.fetch('PHAXIO_API_KEY')
 			if options[:caller_id].nil?
 				sent_fax_response = "Your caller ID number is not set."
 			else
@@ -43,10 +42,12 @@ class Fax < ApplicationRecord
 
 		# if there are two error_codes with the same frequency, the error found first (first recipient) takes precedence
 		def most_common_error(fax, errors = {})
+			p fax
 			fax["recipients"].each do |recipient|
-		  	key = recipient["error_message"]
+		  	p key = recipient["error_message"]
 		  	errors.has_key?(key) ? errors[key]["frequency"] += 1 : errors[key] = { "frequency" => 1 }
 			end
+			p errors.max_by { |error_code, amount| amount["frequency"] }.shift
 	  	errors.max_by { |error_code, amount| amount["frequency"] }.shift
 		end
 

--- a/app/models/fax.rb
+++ b/app/models/fax.rb
@@ -42,11 +42,11 @@ class Fax < ApplicationRecord
 
 		# if there are two error_codes with the same frequency, the error found first (first recipient) takes precedence
 		def most_common_error(fax, errors = {})
-			########## V2.1 WEBHOOK CODE HERE#######################
-			# fax["recipients"].each do |recipient|
-		 #  	key = recipient["error_message"]
-		 #  	errors.has_key?(key) ? errors[key]["frequency"] += 1 : errors[key] = { "frequency" => 1 }
-			# end
+		########### V2.1 WEBHOOK CODE HERE#######################
+		#  fax["recipients"].each do |recipient|
+		#  	 key = recipient["error_message"]
+		#  	 errors.has_key?(key) ? errors[key]["frequency"] += 1 : errors[key] = { "frequency" => 1 }
+		#	 end
 	  # 	errors.max_by { |error_code, amount| amount["frequency"] }.shift
 	  ##########################################################
 

--- a/app/models/fax.rb
+++ b/app/models/fax.rb
@@ -42,13 +42,18 @@ class Fax < ApplicationRecord
 
 		# if there are two error_codes with the same frequency, the error found first (first recipient) takes precedence
 		def most_common_error(fax, errors = {})
-			p "================================ MOST COMMON ERROR METHOD HERE ============================="
-			p fax
-			fax["recipients"].each do |recipient|
-		  	p key = recipient["error_message"]
+			########## V2.1 WEBHOOK CODE HERE#######################
+			# fax["recipients"].each do |recipient|
+		 #  	key = recipient["error_message"]
+		 #  	errors.has_key?(key) ? errors[key]["frequency"] += 1 : errors[key] = { "frequency" => 1 }
+			# end
+	  # 	errors.max_by { |error_code, amount| amount["frequency"] }.shift
+	  ##########################################################
+
+	  	fax["recipients"].each do |recipient|
+		  	key = recipient["error_code"]
 		  	errors.has_key?(key) ? errors[key]["frequency"] += 1 : errors[key] = { "frequency" => 1 }
 			end
-			p errors.max_by { |error_code, amount| amount["frequency"] }.shift
 	  	errors.max_by { |error_code, amount| amount["frequency"] }.shift
 		end
 

--- a/app/models/fax.rb
+++ b/app/models/fax.rb
@@ -5,6 +5,7 @@ class Fax < ApplicationRecord
 		end
 
 		def create_fax(options)
+			ENV.fetch('PHAXIO_API_KEY')
 			if options[:caller_id].nil?
 				sent_fax_response = "Your caller ID number is not set."
 			else

--- a/app/views/mailgun_mailer/fax_email.html.erb
+++ b/app/views/mailgun_mailer/fax_email.html.erb
@@ -33,10 +33,12 @@
 	  <h2>Recipients</h2>
 	  <% @fax["recipients"].each do |recipient| %>
 	    <div class="recipient">
-	      <p><b>Number:</b> <%= recipient["phone_number"] %></p>
+	      <!-- <p><b>Number:</b> --> <%#= recipient["phone_number"] %><!-- </p> -->
+	      <p><b>Number:</b> <%= recipient["number"] %></p>
 	      <p><b>Status:</b> <%= recipient["status"] %></p>
 	      <% if @fax["status"] != "success" %>
-					<p><b>Error Message:</b> <%= recipient["error_message"] %></p>
+					<!-- <p><b>Error Message:</b> --> <%#= recipient["error_message"] %><!-- </p> -->
+					<p><b>Error Message:</b> <%= recipient["error_code"] %></p>
 				<% end %>
 	    </div>
 	  <% end %>


### PR DESCRIPTION
Converted application over to run V1 webhooks instead of V2.1. Left code commented out that supports V2.1 webhook functionality in the following places:
1.) Mailgun Faxes Controller
2.) Fax Model (most_common_error) method
3.) mailgun_mailer/fax_email.erb template

Also added a quick check to see if a file was attached (makes sure params['attachment-count']) is not nil. This check will notify a user that they need to attach an email.