### PR TITLE
Minor bugfixes reinstated user invite

### DIFF
--- a/app/assets/javascripts/components/confirmationMessage.js
+++ b/app/assets/javascripts/components/confirmationMessage.js
@@ -1,7 +1,6 @@
 const deleteOrganizationMessage = 'Deleting this organization will permanently remove all of its users and other data. This cannot be restored. Are you sure you want to do that?';
 const provisionNumberMessage = 'Purchasing this number will charge $2.00 to your account. Are you sure you want to do that?';
 const userRevokeAccess = "Revoking this user's access will forbid them from logging in or sending/receiving faxes through email.Users with revoked access can be invited again at any time later.  Are you sure you want to do that?";
-const userResetPassword = "This user will be unable to log in until they reset their password using this email address, however email-to-fax and fax-to-email functionality will continue. Are you sure you want to do that?";
 
 phaxMachine.components['confirmationMessage'] = {
 	render: function() {
@@ -23,12 +22,6 @@ phaxMachine.components['confirmationMessage'] = {
 				for (let i = 0; i < allRevokeAccessButtons.length; i++) {
 					new ConfirmationMessage(userRevokeAccess, allRevokeAccessButtons[i]);
 				}
-			case 'user-table':
-				let allResetPasswordButtons = document.getElementsByClassName("reset-password");
-				for (let i = 0; i < allResetPasswordButtons.length; i++) {
-					new ConfirmationMessage(userResetPassword, allResetPasswordButtons[i]);
-				}
-				break;
 		}
 	}
 };

--- a/app/assets/javascripts/components/confirmationMessage.js
+++ b/app/assets/javascripts/components/confirmationMessage.js
@@ -1,6 +1,7 @@
 const deleteOrganizationMessage = 'Deleting this organization will permanently remove all of its users and other data. This cannot be restored. Are you sure you want to do that?';
 const provisionNumberMessage = 'Purchasing this number will charge $2.00 to your account. Are you sure you want to do that?';
-const userRevokeAccess = "Revoking this user's access will forbid them from logging in or sending/receiving faxes through email.Users with revoked access can be invited again at any time later.  Are you sure you want to do that?"
+const userRevokeAccess = "Revoking this user's access will forbid them from logging in or sending/receiving faxes through email.Users with revoked access can be invited again at any time later.  Are you sure you want to do that?";
+const userResetPassword = "This user will be unable to log in until they reset their password using this email address, however email-to-fax and fax-to-email functionality will continue. Are you sure you want to do that?";
 
 phaxMachine.components['confirmationMessage'] = {
 	render: function() {
@@ -21,6 +22,11 @@ phaxMachine.components['confirmationMessage'] = {
 				let allRevokeAccessButtons = document.getElementsByClassName("revoke-access");
 				for (let i = 0; i < allRevokeAccessButtons.length; i++) {
 					new ConfirmationMessage(userRevokeAccess, allRevokeAccessButtons[i]);
+				}
+			case 'user-table':
+				let allResetPasswordButtons = document.getElementsByClassName("reset-password");
+				for (let i = 0; i < allResetPasswordButtons.length; i++) {
+					new ConfirmationMessage(userResetPassword, allResetPasswordButtons[i]);
 				}
 				break;
 		}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
 class ApplicationController < ActionController::Base
 	include SessionsHelper
-
 	before_action :authenticate_user!, if: :devise_controller?
 	before_action :configure_permitted_parameters, if: :devise_controller?
+
 	DENIED = "Permission denied.".freeze
 
   protected

--- a/app/controllers/fax_logs_controller.rb
+++ b/app/controllers/fax_logs_controller.rb
@@ -96,6 +96,9 @@ class FaxLogsController < ApplicationController
 
 		# Create a hash of Organization object data to reference later. Prevents program from querying the database constantly
 		def set_organization_or_organizations
+			# Sends logged out user to root if they access /fax_logs while logged out.
+			redirect_to(root_path) and return if !user_signed_in?
+
 			@organizations = {}
 			if is_admin?
 				if is_all_or_is_nil?(filtering_params[:organization])

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -35,5 +35,4 @@ class Users::PasswordsController < Devise::PasswordsController
     	redirect_to(users_password_set_new_user_password_path(:reset_password_token => params[:user][:reset_password_token], :new_user => true))
     end
   end
-
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -37,7 +37,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   		User.welcome(possible_user.id, sign_up_params[:permission]) # <-- Resends user invite email
 
-  		flash[:notice] = "Access has been reinstated for #{possible_user.email}"
+  		flash[:notice] = "Access has been reinstated for #{possible_user.email}. Don't forget to link #{possible_user.email} to a fax number, otherwise they cannot send or receive faxes."
 
   	else
 	    build_resource(sign_up_params)
@@ -55,7 +55,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 		    end
 		    
 	      if resource.active_for_authentication?
-	        flash[:notice] = "#{resource.email} has been invited."
+	        flash[:notice] = "#{resource.email} has been invited. Don't forget to link #{resource.email} to a fax number, otherwise they cannot send or receive faxes."
 	      else
 	        flash[:notice] = "signed_up_but_#{resource.inactive_message}"
 	        expire_data_after_sign_in!

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
 	
 	# Get list of organizations for the Admin, after an org is selected, it goes to the Index route in this controller
 	def org_index
-		@organizations = Organization.all
+		@organizations = Organization.all.order(:label)
 	end
 
 	def index # with_deleted is a Paranoia gem method that includes soft-deleted users

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -66,7 +66,7 @@ class UsersController < ApplicationController
 			# For the rare edge case when a User object has no permission object associated with it
 			if @user.user_permission.nil?
 				UserPermission.create!(permission: UserPermission::USER, user_id: @user.id)
-				@user.includes(:user_permission).reload
+				@user.reload
 			end
 		end
 

--- a/app/mailers/phax_machine_mailer.rb
+++ b/app/mailers/phax_machine_mailer.rb
@@ -6,7 +6,7 @@ class PhaxMachineMailer < Devise::Mailer
   ALTERNATE_LOGO_PATH = 'https://t3com.com/wp-content/uploads/2016/05/t3comm-process-colors.jpg'.freeze
 
   def manager_welcome_invite(record, token, opts = {})
-  	opts[:from] = ENV.fetch('ADMIN_EMAIL')
+  	opts[:from] = ENV["FROM_EMAIL"]
   	opts[:subject] = "You've been invited to manage #{record.organization.label}."
     @token = token
     @logo_link = LogoLink.first ? LogoLink.first.logo_url : ALTERNATE_LOGO_PATH

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -25,7 +25,7 @@
 															<% if organization_fax_number.manager_label.present? %>
 														 		- <%= organization_fax_number.manager_label %>
 														 	<% end %>
-														 </option>
+														</option>
 													<% end %>
 												</select>
 											</div>
@@ -37,23 +37,24 @@
 								</div>
 							</div>
 						</div>
+						<div style="height:30px;" class="row">
 
-						<div class="row" style="height:10px">
-							<div class="col-lg-6">
+							<div class="col-lg-5">
 								<p>
-									<span style="color:green;margin-left:30px">
+									<span style="color:green;margin-left:30px;">
 										<i class="fa fa-fw fa-check" aria-hidden="true"></i>
 									</span>
 									<i><%= @organization.label %>'s manager</i>
 								</p>
 							</div>
+
 							<div class="col-lg-6">
-								<p style="margin-right:70px" class="pull-right">
+								<p class="pull-right">
 									<i>To reinvite an inactive user, use the form above</i>
 								</p>
 							</div>
-						</div>
 
+						</div>
 						<table id="user-table" class="table table-sm table-hover">
 							<thead class="thead-dark">
 								<tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,53 +1,66 @@
-<body data-page="user-table" class="bg-dark coverup">
+<body data-components="confirmationMessage" data-page="user-table" class="bg-dark coverup">
   <div class="container coverup">
     <div class="card card-login mx-auto mt-5">
       <div class="card-header"><%= @organization.label %></div>
       <div class="card-body">
         <div class="mb-8">
 					<% if @users %>
-					<div class="container-fluid user-form form-group">
-						<div class="row">
-							<div class="inline-input-margin col-lg-12">
-								<%= form_for :user, url: "/users", method: :post, class: "form-inline" do |f| %>
-									<%= f.hidden_field :organization_id, value: "#{@organization.id}" %>
-									<%= f.hidden_field :permission, value: "#{UserPermission::USER}" %>
-									<div class="row justify-content-center">
-										<div class="form-group col-lg-4">
-											<strong><%= f.label :email, "Email:", class: "pull-left" %></strong>
-											<%= f.email_field :email, class: "form-control" %>
+						<div class="container-fluid user-form form-group">
+							<div class="row">
+								<div class="inline-input-margin col-lg-12">
+									<%= form_for :user, url: "/users", method: :post, class: "form-inline" do |f| %>
+										<%= f.hidden_field :organization_id, value: "#{@organization.id}" %>
+										<%= f.hidden_field :permission, value: "#{UserPermission::USER}" %>
+										<div class="row justify-content-center">
+											<div class="form-group col-lg-4">
+												<strong><%= f.label :email, "Email:", class: "pull-left" %></strong>
+												<%= f.email_field :email, class: "form-control" %>
+											</div>
+											<div class="form-group col-lg-4">
+												<strong><%= f.label :caller_id_number, "Caller ID Number:", class: "pull-left" %></strong>
+												<select id="caller-id-select" class="form-control form-inline" name="user[caller_id_number]">
+													<% @organization.fax_numbers.each do |organization_fax_number| %>
+														<option name="user[caller_id_number]" value="<%= organization_fax_number.fax_number %>" selected="selected">
+															<%= FaxNumber.format_pretty_fax_number(organization_fax_number.fax_number) %>
+															<% if organization_fax_number.manager_label.present? %>
+														 		- <%= organization_fax_number.manager_label %>
+														 	<% end %>
+														 </option>
+													<% end %>
+												</select>
+											</div>
+											<div class="col-lg-2 form-group force-down-button">
+												<%= f.submit "Invite User", class: "btn btn-success" %>
+											</div>
 										</div>
-										<div class="form-group col-lg-4">
-											<strong><%= f.label :caller_id_number, "Caller ID Number:", class: "pull-left" %></strong>
-											<select id="caller-id-select" class="form-control form-inline" name="user[caller_id_number]">
-												<% @organization.fax_numbers.each do |organization_fax_number| %>
-													<option name="user[caller_id_number]" value="<%= organization_fax_number.fax_number %>" selected="selected">
-														<%= FaxNumber.format_pretty_fax_number(organization_fax_number.fax_number) %>
-														<% if organization_fax_number.manager_label.present? %>
-													 		- <%= organization_fax_number.manager_label %>
-													 	<% end %>
-													 </option>
-												<% end %>
-											</select>
-										</div>
-										<div class="col-lg-2 form-group force-down-button">
-											<%= f.submit "Invite New User", class: "btn btn-success" %>
-										</div>
-									</div>
-								<% end %>
+									<% end %>
+								</div>
 							</div>
 						</div>
-					</div>
 
-						<div class="col-lg-5">
-							<p><span style="color:green"><i class="fa fa-fw fa-check" aria-hidden="true"></i></span><i> Indicates the user is <%= @organization.label %>'s manager </i></p>
+						<div class="row" style="height:10px">
+							<div class="col-lg-6">
+								<p>
+									<span style="color:green;margin-left:30px">
+										<i class="fa fa-fw fa-check" aria-hidden="true"></i>
+									</span>
+									<i><%= @organization.label %>'s manager</i>
+								</p>
+							</div>
+							<div class="col-lg-6">
+								<p style="margin-right:70px" class="pull-right">
+									<i>To reinvite an inactive user, use the form above</i>
+								</p>
+							</div>
 						</div>
+
 						<table id="user-table" class="table table-sm table-hover">
 							<thead class="thead-dark">
 								<tr>
-									<th></th>
+									<th><!-- Manager checkbox here--></th>
 									<th class="text-center">Email Address:</th>
-									<th class="text-center">Caller ID</th>
-									<th class="text-center">Active</th>
+									<th class="text-center">Caller ID:</th>
+									<th class="text-center">Active:</th>
 									<th></th>
 								</tr>
 							</thead>
@@ -57,15 +70,18 @@
 									<% if user.user_permission && user.user_permission.permission == UserPermission::MANAGER %>
 										<td class="text-center align-middle"><span style="color:green"><i class="fa fa-check" aria-hidden="true"></i></span></td>
 									<% else %>
-									<td></td>
+										<td></td>
 									<% end %>
 									<td class="text-center"><%= user.email %></td>
 									<td class="text-center"><%= FaxNumber.format_pretty_fax_number(user.caller_id_number) if user.caller_id_number %></td>
 									<% if user.deleted_at.nil? %>
 										<td class="text-center" style="color:green;"><i class="fa fa-fw fa-check-circle" aria-hidden="true"></i></td>
-										<td class="text-center"><%= link_to "Edit", edit_user_path(user), class: "btn btn-sm btn-success" %></td>
+										<td class="text-center">
+											<%= link_to "<i class='fa fa-pencil fa-fw' aria-hidden='true'></i>&nbsp;&nbsp;Edit&nbsp;".html_safe, edit_user_path(user), class: "btn btn-sm btn-success" %>
+										</td>&nbsp;
 									<% else %>
 										<td class="text-center" style="color:crimson;"><i class="fa fa-fw fa-times-circle" aria-hidden="true"></i></td>
+										<td></td>
 										<td></td>
 									<% end %>
 								<tr>

--- a/spec/features/fax_log_spec.rb
+++ b/spec/features/fax_log_spec.rb
@@ -141,5 +141,14 @@ RSpec.feature "Fax Logs", :type => :feature do
 				expect(page).to have_text("File")
 			end
 		end
+
+		it "when not logged in redirects to the sign-in page" do
+			visit(fax_logs_path)
+			expect(page).to have_button("Log In")
+			expect(page).to have_field("user[email]")
+			expect(page).to have_field("user[password]")
+			expect(page).to have_current_path("http://www.example.com/users/sign_in")
+			expect(page).to have_link('Log In', href: new_user_session_path)
+		end
 	end
 end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "User Pages", :type => :feature do
 			expect(page).to have_current_path("/users?organization_id=#{org.id}")
 			expect(page).to have_field("user[email]")
 			expect(page).to have_field("user[caller_id_number]")
-			expect(page).to have_text("Indicates the user is #{org.label}'s manager")
+			expect(page).to have_text("#{org.label}'s manager")
 			expect(page).to have_table("user-table")
 			within_table("user-table") do
 				expect(page).to have_text("Email Address")
@@ -276,7 +276,7 @@ RSpec.feature "User Pages", :type => :feature do
 			visit(users_path)
 			fill_in("user[email]", with: "#{user1.email}")
 			select("(773) 867-5308", from: "user[caller_id_number]", match: :first)
-			click_on("Invite New User")
+			click_on("Invite User")
 			expect(page).to have_text("Access has been reinstated for #{user1.email}")
 			expect(page).to have_current_path(users_path)
 		end
@@ -288,7 +288,7 @@ RSpec.feature "User Pages", :type => :feature do
 			visit(users_path)
 			fill_in("user[email]", with: "mr.saturn@aol.com")
 			select("(773) 867-5308", from: "user[caller_id_number]", match: :first)
-			click_on("Invite New User")
+			click_on("Invite User")
 			expect(page).to have_text("mr.saturn@aol.com has been invited.")
 		end
 
@@ -298,7 +298,7 @@ RSpec.feature "User Pages", :type => :feature do
 			click_link("Phaxio Test Company")
 			fill_in("user[email]", with: "mr.saturn@aol.com")
 			select("(773) 867-5308", from: "user[caller_id_number]", match: :first)
-			click_on("Invite New User")
+			click_on("Invite User")
 			expect(page).to have_text("mr.saturn@aol.com has been invited.")
 		end
 
@@ -312,7 +312,7 @@ RSpec.feature "User Pages", :type => :feature do
 
 			fill_in("user[email]", with: "mr.saturn1@aol.com")
 			select("(773) 867-5307", from: "user[caller_id_number]", match: :first)
-			click_on("Invite New User")
+			click_on("Invite User")
 			expect(page).to have_current_path("http://www.example.com/")
 			expect(page).to have_text(ApplicationController::DENIED)
 		end


### PR DESCRIPTION
* Added minor cosmetic tweaks including:
- Org-users page is now sorted alphabetically
- user-index page styling tweaks
- confirmation messages remind admin or manager to add newly created or reinstated user to a fax number before they can fax

* Adjusted unit tests to include less verbose text
* Reinstated users are now sent a password reset email when reinstated
* When a manager's access is revoked, the user is no longer used as that organization's manager_id
